### PR TITLE
feat(ignore): don't use lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 
 # Cookies
 state.json
+
+# Npm lock
+package-lock.json


### PR DESCRIPTION
Don't use `package-lock.json` now.